### PR TITLE
Make the extension not persistent and use event filters

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -23,14 +23,12 @@ chrome.webNavigation.onHistoryStateUpdated.addListener( function onHistoryStateU
         { file: '/css/statify.css' },
         { file: '/css/layout.css' },
     ] )
-} )
+}, { url : [{ hostSuffix : 'trakt.tv' }] } )
 
 
-chrome.tabs.onUpdated.addListener( function onUpdated( tabId, changeInfo, tab ) {
-    if ( tab.url.indexOf( 'https://trakt.tv' ) == 0 )
-        chrome.pageAction.show( tabId )
-
-} )
+chrome.webNavigation.onCompleted.addListener(function onUpdated( details ) {
+    chrome.pageAction.show( details.tabId )
+}, { url : [{ hostSuffix : 'trakt.tv' }] } )
 
 
 function queueExecution( tabId, execMethod, injectDetailsArray ) {

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "name": "Trakt improver DEV",
   "short_name" : "trakttvstats",
   "description": "Add various improvements to Trakt.tv",
-  "version": "0.5.2",
-  "version_name": "0.5 (0.5.2)",
+  "version": "0.5.3",
+  "version_name": "0.5 (0.5.3)",
   "permissions": [
     "storage",
     "tabs",
@@ -14,7 +14,8 @@
     "https://api.themoviedb.org/*"
   ],
   "background": {
-      "page": "background.html"
+      "page": "background.html",
+      "persistent": false
   },
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
"persistent": false added to the manifest. It allows the extension to be automatically unloaded from the RAM by Chrome

[Relevant documentation](https://developer.chrome.com/extensions/background_migration)

Bumped the version number as well.