### PR TITLE
Fix country code emoji when using ISO-3166-1

### DIFF
--- a/js/translate.js
+++ b/js/translate.js
@@ -116,6 +116,11 @@ function insertI18nImage( parent, sel, showInfo, callback ) {
 function countryCodeEmoji( countryCode ) {
     if ( typeof countryCode !== 'string' )
         throw new TypeError( 'argument must be a string' )
+    if ( countryCode.includes( '-' ) ) {
+        //If the country code contains a "-", it's probably formatted using ISO-3166-1, like pt-BR
+        //The country code to use for the emoji conversion is then after the dash.
+        countryCode = countryCode.split( '-' )[ 1 ]
+    }
     const cc = countryCode.toUpperCase()
     return ( /^[A-Z]{2}$/.test( cc ) )
         ? String.fromCodePoint( ...[ ...cc ].map( c => c.charCodeAt() + 127397 ) )


### PR DESCRIPTION
Fixes the issue seen in #39 causing the country emoji test to fail when using languages like "pt-BR", (ISO-639-1 followed by ISO-3166-1).

According to the [TMDB API documentation](https://developers.themoviedb.org/3/getting-started/languages), it won't be accurate when the translation defaults to another language.

>The last example to show you would be a request for pt-US. This is not a valid translation and will default to pt-PT.

In the case above, we would get the US flag emoji anyway, and it won't be possible to fix this if the API doesn't return us the actual applied code to use.