### PR TITLE
Fix invisible checkmarks in the extension settings

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -35,10 +35,9 @@ input,
 select {
     border-radius: 2px;
     border: 1px solid #ccc;
-    padding: .2em .5em;
 }
 select {
-    padding-right: 0;
+    padding: .2em 0 .2em .5em;
 }
 
 .titlesZone {


### PR DESCRIPTION
Fixes #45 by removing the padding from input elements, and keeping it only for select elements. It fixes the issue without altering the look of the settings page.

It is to note that the issue can only be seen through the extensions settings frame, and not by opening the options page in a full browser tab