### PR TITLE
Rework custom external links search queries : More relevant titles, and fixes 

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -12,6 +12,7 @@ if ( !options ) {
         i18nPosters: 'Disable',
         i18nSynopsis: 'Both',
         layoutExternalLinks: '',
+        layoutSpecifyYearInExternalLinks:false,
         layoutMultilineTitles: false,
         layoutSynopsisMaxLines: 5,
         i18nTitlesLines: [

--- a/js/layout.js
+++ b/js/layout.js
@@ -88,7 +88,8 @@ function getMediaFullTitle(includeYear=false) {
     //region Try to append year if requested
     if (includeYear){
         var year=titleContainer.querySelector('span.year')
-        title=(title+" " +year.textContent).trim();//We trim in case the year is empty (not specified)
+        if (year!=null) //Year is null if we are on a people page
+            title=(title+" " +year.textContent).trim();//We trim in case the year is empty (not specified, on media pages)
     }
     //endregion
 

--- a/js/layout.js
+++ b/js/layout.js
@@ -14,7 +14,7 @@ function addExternalLinks() {
         list = document.querySelector( '.sidebar .external' )
     if ( !list || !options.layoutExternalLinks ) return
 
-    title = document.querySelector( 'h1' ).textContent
+    title = getMediaFullTitle(options.layoutSpecifyYearInExternalLinks)
 
     if ( list.classList.contains( 'is-customized' ) ) return
 
@@ -28,6 +28,71 @@ function addExternalLinks() {
         new_el.innerHTML = domain
         firstlink.parentElement.appendChild( new_el )
     } )
+}
+
+/**
+ * Obtains the full title of the current page's media, including the name of the parent show or season if needed.
+ * Does not include certification, as it is usually not relevant in searches.
+ *
+ * @param includeYear whether to include the year in the title or not. Defaults to false.
+ * @returns {string}
+ * - "<Show Title>: Season <Number> <Episode Title>" on an episode page
+ * - "<Show Title> Season <Number>" on a season page
+ * - "<Show Title>" on a show page
+ * - "<Movie Title>" on an movie page
+ *
+ */
+function getMediaFullTitle(includeYear=false) {
+
+    var title = ""
+
+    //region Add parent media title (for episodes pages, we prepend the episode title with the show+season)
+    var levelUpLink = document.getElementById('level-up-link')
+
+    //If there is a level up link, it means the current page is not a top level element (ie not show or movie)
+    if (levelUpLink !== null) {
+        //In that case we want to add the top level element to the title of the media.
+        // For example, we add "<ShowTitle>: Season <Number>" before episode names.
+
+        var mediaParentsElement = levelUpLink.parentElement
+        //levelUpLink contains the immediate parent of the media (for an episode, it would be "Season <Number>"),
+        // whereas mediaParentsElement here contains all the parent medias ("<ShowTitle>: Season <Number>")
+
+        title += mediaParentsElement.textContent + " "
+    }
+    //endregion
+
+    //region Add current media title
+    var titleContainer = document.querySelector('#summary-wrapper h1')
+    //#summary-wrapper is the heading of the page, containing title, ratings, and more. it stops just before the synopsis
+    //The only h1 child is the one containing the direct title of the current page's media. Either :
+    // - "<MovieTitle> <year><certification>", "<ShowTitle> <year><certification>" on a movie/show page
+    // - "Season <Number> <year><certification>" on a season page
+    // - "<SeasonNumber>x<EpisodeNumber> <Episode name> <year><certification>" on an episode page
+
+    //If this is an episode page, titleContainer has a span.main-title child node with the episode name in english,
+    // along with span.year, and span.certification
+    var episodeTitleElement = titleContainer.querySelector('.main-title')
+    //If it is not an episode page (so show/movie/season page), the "titleContainer" element contains multiple nodes
+    // with the first one being just text (the show/movie/season title), then span.year, and span.certification
+    var otherMediaTitleElement = titleContainer.childNodes[0]
+
+    //either an episode title if it exists, or the other title.
+    var titleElement = episodeTitleElement || otherMediaTitleElement
+
+    //Trakt likes adding trailing whitespaces sometimes, so we trim the text to avoid unpredictable behavior
+    title += titleElement.textContent.trim()
+    //endregion
+
+
+    //region Try to append year if requested
+    if (includeYear){
+        var year=titleContainer.querySelector('span.year')
+        title=(title+" " +year.textContent).trim();//We trim in case the year is empty (not specified)
+    }
+    //endregion
+
+    return title
 }
 
 function limitSynopsisLines() {

--- a/js/layout.js
+++ b/js/layout.js
@@ -24,7 +24,7 @@ function addExternalLinks() {
         var goourl = 'http://www.google.com/search?btnI&q=',
             firstlink = list.querySelector( 'a' ),
             new_el = firstlink.cloneNode( true )
-        new_el.href = goourl + title + ' ' + domain
+        new_el.href = goourl + encodeURIComponent(title + ' ' + domain)
         new_el.innerHTML = domain
         firstlink.parentElement.appendChild( new_el )
     } )

--- a/js/options.js
+++ b/js/options.js
@@ -46,6 +46,7 @@ $( () => {
             i18nPosters: 'Disable',
             i18nSynopsis: 'Both',
             layoutExternalLinks: '',
+            layoutSpecifyYearInExternalLinks:false,
             layoutSynopsisMaxLines: 5,
             layoutMultilineTitles: false,
             i18nTitlesLines: [

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "name": "Trakt improver DEV",
   "short_name" : "trakttvstats",
   "description": "Add various improvements to Trakt.tv",
-  "version": "0.5.4",
-  "version_name": "0.5 (0.5.4)",
+  "version": "0.5.5",
+  "version_name": "0.5 (0.5.5)",
   "permissions": [
     "storage",
     "tabs",

--- a/options.html
+++ b/options.html
@@ -23,6 +23,10 @@
         <input type="text" placeholder="ex: allocine,criticker" data-option="layoutExternalLinks">
     </label>
     <label class="row">
+        <span class="label">Specify release year in custom external links</span>
+        <div><input type="checkbox" data-option="layoutSpecifyYearInExternalLinks"></div>
+    </label>
+    <label class="row">
         <span class="label">Multiline titles</span>
         <div><input type="checkbox" data-option="layoutMultilineTitles"></div>
     </label>

--- a/test/test.js
+++ b/test/test.js
@@ -165,7 +165,8 @@ describe('External Links', function () {
 
             let obtainedUrl = await page.$eval( '.sidebar .external li', el => el.lastElementChild.href )
             let expectedUrl = new URL('http://www.google.com/search?btnI&q='
-                + testValues.expectedTitleWithYear + ' ExternalLink').href
+                + encodeURIComponent(testValues.expectedTitleWithYear + ' ExternalLink')
+            ).href
             assert.strictEqual(obtainedUrl, expectedUrl, 'the obtained url does not match')
         })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -27,13 +27,13 @@ let browser
 let page
 let client
 
-before( 'start browser and extension', async function() {
+before( 'start browser and extension, and accept Trakt data compliance popup', async function() {
     this.enableTimeouts( false )
 
     browser = await puppeteer.launch( chromiumOptions )
 
     // hack, waits until targets are ready
-    await delay( 2000 )
+    await delay( 5000 )
 
     // see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-target
     let extensionTarget = browser.targets()
@@ -42,6 +42,15 @@ before( 'start browser and extension', async function() {
     assert.ok( extensionTarget, 'could not find the extension target' )
 
     client = await extensionTarget.createCDPSession()
+    page = await browser.newPage()
+    try {
+        await page.goto('https://trakt.tv/movies/trending', {waitUntil: 'networkidle2'})
+        await page.click('#sncmp-popup-ok-button')
+        console.log("GDPR popup accepted")
+    } catch {
+        console.warn("GDPR popup not detected.")
+    }
+    page.close()
 } )
 
 after( 'detach extension and close browser', async function() {


### PR DESCRIPTION
Fixes #40 and fixes #19 and fixes #48

- `The Sopranos` is the returned title for a show / movie
- `The Sopranos : Season 1` is the returned title for a season
- `The Sopranos : Season 1 Denial, Anger, Acceptance` is the returned title for an episode

And the year can be specified in the search query too - I added a user setting exposing that feature. That adds the year to the end of the string for show/movies/seasons (not episodes).

I tested these additions and added the tests to the test suite.

Additionally, the version number was bumped to 0.5.5, and the test suite fixed to handle the trakt GDPR popup.