### PR TITLE
Fixed the people pages features (stats, translation)

### DIFF
--- a/css/statify.css
+++ b/css/statify.css
@@ -375,6 +375,9 @@
 .ttvposters.filtered ~ .posters {
     display: none;
 }
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
+position : unset !important;
+}
 
 /*
 ** Nav

--- a/js/statify.js
+++ b/js/statify.js
@@ -8,7 +8,8 @@ function processMovies( parent ) {
     for ( let i = 0; i < e_movies.length; i++ ) {
         let m = e_movies[ i ],
             id = m.dataset.movieId || m.dataset.showId,
-            cat = m.parentNode.previousSibling.id,
+            fullcat = m.parentNode.parentNode.id, //A movie/show is in a div, itself in another div that has an id describing the category.
+            cat = fullcat.split("-")[0]; //Since the id is suffixed with "-credits" (Ex "production-credits" or "actor-credits"), we only keep the first part.
             el_infos = m.querySelector( '.titles' ),
             year = el_infos.children[ 1 ].firstChild.nodeValue,
             decade = yearDecade( year ),
@@ -270,7 +271,8 @@ function updateYearsSelection() {
     if ( filters.decade ) {
         // determine current index and select current label
         var labels = e_yearschart.querySelectorAll( '.ct-labels > *' )
-        for ( let idx = 0; idx < labels.length; idx++ ) {
+        var idx
+        for ( idx = 0; idx < labels.length; idx++ ) {
             var el = labels[ idx ]
             if ( labels[ idx ].firstChild.firstChild.nodeValue == '' + filters.decade ) {
                 labels[ idx ].classList.add( 'selected' )

--- a/js/translate.js
+++ b/js/translate.js
@@ -284,8 +284,10 @@ function translatePage( el, tmdbPath ) {
         TMDB.updateCache()
         insertI18nImage( el, '#info-wrapper', result )
         renderPageTitle( el, result )
+        if(result.overview==null)
+            result.overview=result.biography
         renderSynopsis( el, '.info #overview', result.overview )
-        renderSynopsis( el, '.info #biography + p', result.biography )
+        //This apparently worked before a Trakt design change : renderSynopsis( el, '.info #biography + p', result.biography )
         renderReleasesDatesList( el, result.releases )
         el.classList.add( 'translated' )
     } ).catch( error )


### PR DESCRIPTION
This is a small commit to fix issues brought by what I guess are Trakt website design changes. Closes #49 .

- [x] Fix the stats not displaying anymore on people pages, and layout issues
- [x] Fix the translations not displaying anymore on people pages 

> Notice for users : Since this repository wasn't monitored by the owner for a while, these fixes may take a long time to get merged and reach the Chrome Web Store. If you wish to test an in development version, a 0.5.6 version can be found on my [fork](https://github.com/AmineI/trakttvstats/tree/0.5.6), containing all my PR fixes that are awaiting to be merged in this repository. 
> The "install unpacked extension" chromium feature can be used to install an in-development extension from source code. 